### PR TITLE
docs: Add libfuse2 requirement for AppImage installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ paprwall-gui           # Launch
 ### Option 2: Linux Packages
 - `.deb`: `sudo dpkg -i paprwall_*.deb`
 - `.rpm`: `sudo dnf install paprwall_*.rpm`  
-- AppImage: `chmod +x PaprWall-*.AppImage && ./PaprWall-*.AppImage`
+- AppImage: 
+  ```bash
+  # Install FUSE dependency (required for AppImage)
+  sudo apt install libfuse2  # Ubuntu/Debian
+  # sudo dnf install fuse-libs  # Fedora/RHEL
+  
+  # Run AppImage
+  chmod +x PaprWall-*.AppImage && ./PaprWall-*.AppImage
+  ```
 
 ### Option 3: Windows
 1. Download `.zip` from [Releases](https://github.com/riturajprofile/paprwall/releases/latest)


### PR DESCRIPTION
## Description
This PR adds documentation for the `libfuse2` dependency required to run AppImage builds.

## Changes
- ✅ Added libfuse2 installation instructions in README.md
- ✅ Included commands for Ubuntu/Debian (`apt`) and Fedora/RHEL (`dnf`)
- ✅ Updated AppImage section with clear step-by-step instructions

## Problem Solved
Users on newer Linux distributions (Ubuntu 22.04+) were getting this error:
```
dlopen(): error loading libfuse.so.2
AppImages require FUSE to run.
```

## Testing
- ✅ Tested on Ubuntu 24.04
- ✅ AppImage launches successfully after installing libfuse2

Fixes #2